### PR TITLE
Fix warning deprecation message for PHP 8.4

### DIFF
--- a/src/DotEnv.php
+++ b/src/DotEnv.php
@@ -26,7 +26,7 @@ class DotEnv
      */
     protected array $processors = [];
 
-    public function __construct(string $path, array $processors = null)
+    public function __construct(string $path, ?array $processors = null)
     {
         if (!file_exists($path)) {
             throw new InvalidArgumentException(sprintf('%s does not exist', $path));
@@ -66,7 +66,7 @@ class DotEnv
         }
     }
 
-    private function setProcessors(array $processors = null): void
+    private function setProcessors(?array $processors = null): void
     {
         /**
          * Fill with default processors


### PR DESCRIPTION
Hi again, if I use this package with pho 8.4 I get this warn:

```
Deprecated: PhpDevCommunity\DotEnv::__construct(): Implicitly marking parameter $processors as nullable is deprecated, the explicit nullable type must be used instead in /var/www/api/vendor/phpdevcommunity/php-dotenv/src/DotEnv.php on line 29

Deprecated: PhpDevCommunity\DotEnv::setProcessors(): Implicitly marking parameter $processors as nullable is deprecated, the explicit nullable type must be used instead in /var/www/api/vendor/phpdevcommunity/php-dotenv/src/DotEnv.php on line 69
```